### PR TITLE
Updated to support Airflow 2 packages

### DIFF
--- a/fab_oidc/security.py
+++ b/fab_oidc/security.py
@@ -3,11 +3,11 @@ from flask_appbuilder.security.sqla.manager import SecurityManager
 from flask_oidc import OpenIDConnect
 from .views import AuthOIDCView
 from logging import getLogger
+
 log = getLogger(__name__)
 
 
 class OIDCSecurityManagerMixin:
-
     def __init__(self, appbuilder):
         super().__init__(appbuilder)
         if self.auth_type == AUTH_OID:
@@ -20,19 +20,34 @@ class OIDCSecurityManager(OIDCSecurityManagerMixin, SecurityManager):
 
 
 try:
-    from airflow.www_rbac.security import AirflowSecurityManager
+    from airflow.www.security import AirflowSecurityManager
 
-    class AirflowOIDCSecurityManager(OIDCSecurityManagerMixin,
-                                     AirflowSecurityManager):
+    class AirflowOIDCSecurityManager(OIDCSecurityManagerMixin, AirflowSecurityManager):
         pass
+
+
 except ImportError:
-    log.debug('Airflow not installed')
+    log.debug("Airflow 2 not installed")
+
+    try:
+        from airflow.www_rbac.security import AirflowSecurityManager
+
+        class AirflowOIDCSecurityManager(
+            OIDCSecurityManagerMixin, AirflowSecurityManager
+        ):
+            pass
+
+    except ImportError:
+        log.debug("Airflow 1 not installed")
 
 try:
     from superset.security import SupersetSecurityManager
 
-    class SupersetOIDCSecurityManager(OIDCSecurityManagerMixin,
-                                      SupersetSecurityManager):
+    class SupersetOIDCSecurityManager(
+        OIDCSecurityManagerMixin, SupersetSecurityManager
+    ):
         pass
+
+
 except ImportError:
-    log.debug('Superset not installed')
+    log.debug("Superset not installed")

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def desc():
 
 setup(
     name='fab_oidc',
-    version='0.0.9',
+    version='0.1.0',
     url='https://github.com/ministryofjustice/fab-oidc/',
     license='MIT',
     author='ministryofjustice',


### PR DESCRIPTION
Airflow 2 moved several packages locations, so this fix included a version bump and a fix to where the `AirflowSecurityManager` class lives.